### PR TITLE
refactor: Migrate to Dokkatoo

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,10 +24,10 @@ jobs:
           distribution: zulu
 
       - name: Build documentation
-        run: ./gradlew :library:dokkaHtml
+        run: ./gradlew :library:dokkatooGeneratePublicationHtml
 
       - name: Publish documentation
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
           BRANCH: gh-pages
-          FOLDER: library/build/docs
+          FOLDER: library/build/docs/html

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
 plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.dokkatoo) apply false
 }
 
 tasks.register<Delete>("clean") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-agp_version = "8.2.0"
+agp_version = "8.2.1"
 coroutines_version = "1.7.1"
 kotlin_version = "1.9.21"
 serialization_version = "1.5.1"
-dokka_version = "1.9.10"
+dokkatoo_version = "2.1.0"
 
 [libraries]
 coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines_version" }
@@ -19,5 +19,5 @@ rxjava = { module = "io.reactivex:rxjava", version = "1.3.8" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "agp_version" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka_version" }
+dokkatoo = { id = "dev.adamko.dokkatoo", version.ref = "dokkatoo_version" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin_version" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,12 +1,10 @@
-import java.net.URL
-import org.jetbrains.dokka.DokkaConfiguration.Visibility
-import org.jetbrains.dokka.gradle.DokkaTask
+import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier
 
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     `maven-publish`
-    alias(libs.plugins.dokka)
+    alias(libs.plugins.dokkatoo)
 }
 
 val ver = "14"
@@ -49,38 +47,34 @@ dependencies {
     compileOnly(libs.kotlin.json.okio)
 }
 
-tasks.withType<DokkaTask>().configureEach {
-    dokkaSourceSets {
-        named("main") {
-            moduleName.set("extensions-lib")
-            moduleVersion.set(ver)
-            outputDirectory.set(file("build/docs/"))
-            // Speedup doc generation
-            // offlineMode.set(true)
-            includes.from("Module.md")
+dokkatoo {
+    moduleName.set("extensions-lib")
+    moduleVersion.set(ver)
+    dokkatooPublicationDirectory.set(layout.buildDirectory.dir("docs"))
+    dokkatooSourceSets.main {
+        // // Speedup doc generation
+        // // offlineMode.set(true)
+        includes.from("Module.md")
 
-            perPackageOption {
-                matchingRegex.set("android.content")
-                suppress.set(true)
+        perPackageOption {
+            matchingRegex.set("android.content")
+            suppress.set(true)
+        }
+
+        documentedVisibilities(VisibilityModifier.PUBLIC, VisibilityModifier.PROTECTED)
+
+        externalDocumentationLinks {
+            create("okhttp5") {
+                url("https://square.github.io/okhttp/5.x/")
             }
 
-            documentedVisibilities.set(
-                setOf(Visibility.PUBLIC, Visibility.PROTECTED)
-            )
-
-            // Note: this will show up a bruhzillion of warnings due to
-            // https://github.com/Kotlin/dokka/issues/3120
-            externalDocumentationLink {
-                url.set(URL("https://square.github.io/okhttp/5.x/"))
+            create("jsoup") {
+                url("https://jsoup.org/apidocs/")
+                packageListUrl("https://jsoup.org/apidocs/element-list")
             }
 
-            externalDocumentationLink {
-                url.set(URL("https://jsoup.org/apidocs/"))
-                packageListUrl.set(URL("https://jsoup.org/apidocs/element-list"))
-            }
-
-            externalDocumentationLink {
-                url.set(URL("https://reactivex.io/RxJava/1.x/javadoc/"))
+            create("rxjava") {
+                url("https://reactivex.io/RxJava/1.x/javadoc/")
             }
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,3 +1,4 @@
+import dev.adamko.dokkatoo.dokka.parameters.KotlinPlatform
 import dev.adamko.dokkatoo.dokka.parameters.VisibilityModifier
 
 plugins {
@@ -52,9 +53,10 @@ dokkatoo {
     moduleVersion.set(ver)
     dokkatooPublicationDirectory.set(layout.buildDirectory.dir("docs"))
     dokkatooSourceSets.main {
-        // // Speedup doc generation
-        // // offlineMode.set(true)
         includes.from("Module.md")
+
+        // Temporary workaround for https://github.com/Kotlin/dokka/issues/2876.
+        analysisPlatform.set(KotlinPlatform.JVM)
 
         perPackageOption {
             matchingRegex.set("android.content")
@@ -76,6 +78,32 @@ dokkatoo {
             create("rxjava") {
                 url("https://reactivex.io/RxJava/1.x/javadoc/")
             }
+        }
+
+        val packageRoot = projectDir.resolve("src/main/java/eu/kanade/tachiyomi/")
+        sourceLink {
+            localDirectory.set(packageRoot.resolve("util/JsonExtensions.kt"))
+            remoteUrl("https://github.com/aniyomiorg/extensions-lib/tree/main/library/src/main/java/eu/kanade/tachiyomi/util/JsonExtensions.kt")
+            remoteLineSuffix.set("#L")
+        }
+
+        sourceLink {
+            localDirectory.set(packageRoot.resolve("util/CoroutinesExtensions.kt"))
+            remoteUrl("https://github.com/aniyomiorg/extensions-lib/tree/main/library/src/main/java/eu/kanade/tachiyomi/util/CoroutinesExtensions.kt")
+            remoteLineSuffix.set("#L")
+        }
+
+        sourceLink {
+            localDirectory.set(packageRoot.resolve("animesource/"))
+            remoteUrl("https://github.com/aniyomiorg/aniyomi/tree/master/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/animesource/")
+            // The line number is wrong, so we're not going to highlight it.
+            remoteLineSuffix.set("#")
+        }
+
+        sourceLink {
+            localDirectory.set(packageRoot.resolve("network/"))
+            remoteUrl("https://github.com/aniyomiorg/aniyomi/tree/master/core/src/main/java/eu/kanade/tachiyomi/network/")
+            remoteLineSuffix.set("#") // Same as before.
         }
     }
 }


### PR DESCRIPTION
Advantages over pure Dokka:
1. Has more cache opportunities
2. More readable DSL
3. Got rid of `URL()` (= no spam of warnings in gradle 8.3+)
4. Is able to give function sources with a small hack (see commits)
5. Has a fnnuy birb as icon.