### PR TITLE
chore: Reduce a bit of overhead

### DIFF
--- a/library/src/main/java/eu/kanade/tachiyomi/animesource/ConfigurableAnimeSource.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/animesource/ConfigurableAnimeSource.kt
@@ -1,49 +1,32 @@
 package eu.kanade.tachiyomi.animesource
 
-import android.content.SharedPreferences
 import androidx.preference.PreferenceScreen
 
 /**
  * A interface to add user preferences to the source.
  */
 interface ConfigurableAnimeSource {
-
-    /**
-     * Gets instance of [SharedPreferences] scoped to the specific source.
-     *
-     * @since extensions-lib 14
-     */
-    fun getSourcePreferences(): SharedPreferences = throw Exception("stub!")
-
     /**
      * Implementations must override this method to add the user preferences.
-     * 
+     *
      * You can use some stubbed inheritors of [androidx.preference.Preference] here.
-     * 
+     *
      * **Common usage example:**
      * ```
      * // ============================== Settings ==============================
      * override fun setupPreferenceScreen(screen: PreferenceScreen) {
-     *     val videoQualityPref = ListPreference(screen.context).apply {
+     *     ListPreference(screen.context).apply {
      *         key = PREF_QUALITY_KEY // String, like "pref_quality"
-     *         title = PREF_QUALITY_TITLE // String, like "Preferred quality:" 
+     *         title = PREF_QUALITY_TITLE // String, like "Preferred quality:"
      *         entries = PREF_QUALITY_ENTRIES // Array<String>, like arrayOf("240p", "720p"...)
      *         // Another Array<String>. Can be different from the property above, as long it have the same size
      *         // and equivalent values per index.
-     *         entryValues = PREF_QUALITY_VALUES 
+     *         entryValues = PREF_QUALITY_VALUES
      *         setDefaultValue(PREF_QUALITY_DEFAULT)
      *         summary = "%s"
-     *         setOnPreferenceChangeListener { _, newValue ->
-     *             val selected = newValue as String
-     *             val index = findIndexOfValue(selected)
-     *             val entry = entryValues[index] as String
-     *             preferences.edit().putString(key, entry).commit()
-     *         }
-     *     }
-     *     screen.addPreference(videoQualityPref)
+     *     }.also(screen::addPreference)
      * }
      * ```
      */
     fun setupPreferenceScreen(screen: PreferenceScreen)
-
 }

--- a/library/src/main/java/eu/kanade/tachiyomi/util/CoroutinesExtensions.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/util/CoroutinesExtensions.kt
@@ -62,7 +62,7 @@ inline fun <A, B> Iterable<A>.parallelFlatMapBlocking(crossinline f: suspend (A)
 
 /**
  * Parallel implementation of [Iterable.flatMap], but running
- * the transformation function inside a [runCatching] block.
+ * the transformation function inside a try-catch block.
  *
  * @since extensions-lib 14
  */
@@ -70,14 +70,17 @@ suspend inline fun <A, B> Iterable<A>.parallelCatchingFlatMap(crossinline f: sus
     withContext(Dispatchers.IO) {
         map {
             async {
-                runCatching { f(it) }.onFailure(Throwable::printStackTrace).getOrElse { emptyList() }
+                try { f(it) } catch (e: Throwable) {
+                    e.printStackTrace()
+                    emptyList()
+                }
             }
         }.awaitAll().flatten()
     }
 
 /**
  * Thread-blocking parallel implementation of [Iterable.flatMap], but running
- * the transformation function inside a [runCatching] block.
+ * the transformation function inside a try-catch block.
  *
  * @since extensions-lib 14
  */

--- a/library/src/main/java/eu/kanade/tachiyomi/util/JsonExtensions.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/util/JsonExtensions.kt
@@ -16,7 +16,7 @@ import uy.kohesive.injekt.api.get
  * @since extensions-lib 14
  */
 inline fun <reified T> Response.parseAs(transform: (String) -> String): T {
-    val responseBody = use { transform(it.body.string()) }
+    val responseBody = transform(body.string())
     return Injekt.get<Json>().decodeFromString(responseBody)
 }
 
@@ -30,10 +30,8 @@ inline fun <reified T> Response.parseAs(transform: (String) -> String): T {
  * @since extensions-lib 14
  */
 @ExperimentalSerializationApi
-inline fun <reified T> Response.parseAs(): T = use { res ->
-    res.body.source().use {
-        Injekt.get<Json>().decodeFromBufferedSource(serializer(), it)
-    }
+inline fun <reified T> Response.parseAs(): T = body.source().use {
+    Injekt.get<Json>().decodeFromBufferedSource(serializer(), it)
 }
 
 /**
@@ -46,7 +44,7 @@ inline fun <reified T> String.parseAs(transform: (String) -> String): T =
     Injekt.get<Json>().decodeFromString(transform(this))
 
 /**
- * Parses and serializes the String as the type <T>.
+ * Parses and serializes the Json String as the type <T>.
  *
  * @since extensions-lib 14
  */


### PR DESCRIPTION
This commit removes unnecessary `use {}` blocks in OkHttp v5 responses, and replaces a `runCatching` block in `parallelCatchingFlatMap` with a pure try-catch block, to prevent unnecessary boxing of the returned value.

I'm also removing a function that I've exposed before, as it triggers a giant crash. Thankfully no extension is using it.